### PR TITLE
Remove header containing webapp link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,5 +35,3 @@ SparkleCord is designed with privacy as its core principle:
 We welcome contributions! See our [Contributing Guide](CONTRIBUTING.md) for details.
 ## 📝 License
 [MIT License](LICENSE)
-## 💫 Try It Online
-Visit our [demo](https://sparklecord.github.io/app) to try SparkleCord directly in your browser!


### PR DESCRIPTION
Since the webapp has been terminated, the header containing a link of the webapp is removed.